### PR TITLE
Branches filter is not available for merge_group

### DIFF
--- a/.github/workflows/osv-scanner-unified-workflow.yml
+++ b/.github/workflows/osv-scanner-unified-workflow.yml
@@ -18,7 +18,7 @@ on:
   pull_request:
     branches: ["main"]
   merge_group:
-    branches: ["main"]
+    types: [checks_requested]
   schedule:
     - cron: "12 12 * * 1"
   push:


### PR DESCRIPTION
The "branches" filter is not available for merge_group event. It is only for push, pull_request, pull_request_target, workflow_run events. Instead run the workflow when the checks_requested activity has occurred.

Fixes #14.