### PR TITLE
Upgrade osv-scanner to 1.7.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OSV-Scanner CI/CD Action
 
-[![Release v1.7.3](https://img.shields.io/badge/release-v1.7.3-blue?style=flat)](https://github.com/google/osv-scanner-action/releases)
+[![Release v1.7.4](https://img.shields.io/badge/release-v1.7.4-blue?style=flat)](https://github.com/google/osv-scanner-action/releases)
 <!-- Hard coded release version -->
 
 The OSV-Scanner CI/CD action leverages the [OSV.dev](https://osv.dev/) database and the [OSV-Scanner](https://google.github.io/osv-scanner/) CLI tool to track and notify you of known vulnerabilities in your dependencies for over 11 [languages and ecosystems](https://google.github.io/osv-scanner/supported-languages-and-lockfiles/).

--- a/osv-reporter-action/action.yml
+++ b/osv-reporter-action/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: true
 runs:
   using: "docker"
-  image: "docker://ghcr.io/google/osv-scanner-action:v1.7.3"
+  image: "docker://ghcr.io/google/osv-scanner-action:v1.7.4"
   entrypoint: /root/osv-reporter
   args:
     - "${{ inputs.scan-args }}"

--- a/osv-scanner-action/action.yml
+++ b/osv-scanner-action/action.yml
@@ -25,6 +25,6 @@ inputs:
       ./
 runs:
   using: "docker"
-  image: "docker://ghcr.io/google/osv-scanner-action:v1.7.3"
+  image: "docker://ghcr.io/google/osv-scanner-action:v1.7.4"
   args:
     - ${{ inputs.scan-args }}


### PR DESCRIPTION
Upgrading `osv-scanner` to version [1.7.4](https://github.com/google/osv-scanner/releases/tag/v1.7.4). I just copied how #17 did the upgrade last time. We need this in order to run this CI job against our gradle verification-metadata files.

The tool hal the following complete changelog:

Features:
* Support scanning gradle/verification-metadata.xml files.

Misc:
 * Hide unimportant Debian vulnerabilities to reduce noise.
