### PR TITLE
Update to v1.8.2

### DIFF
--- a/.github/workflows/osv-scanner-reusable-pr.yml
+++ b/.github/workflows/osv-scanner-reusable-pr.yml
@@ -56,7 +56,7 @@ jobs:
       - name: "Checkout target branch"
         run: git checkout $GITHUB_BASE_REF
       - name: "Run scanner on existing code"
-        uses: google/osv-scanner-action/osv-scanner-action@3c399db9dd6dd8106a27d280d53c55077d3f7cea # v1.8.1
+        uses: google/osv-scanner-action/osv-scanner-action@f8af5221bae5d45891ae7a23c2f3d0c938334355 # v1.8.2
         continue-on-error: true
         with:
           scan-args: |-
@@ -66,7 +66,7 @@ jobs:
       - name: "Checkout current branch"
         run: git checkout $GITHUB_SHA
       - name: "Run scanner on new code"
-        uses: google/osv-scanner-action/osv-scanner-action@3c399db9dd6dd8106a27d280d53c55077d3f7cea # v1.8.1
+        uses: google/osv-scanner-action/osv-scanner-action@f8af5221bae5d45891ae7a23c2f3d0c938334355 # v1.8.2
         with:
           scan-args: |-
             --format=json
@@ -74,7 +74,7 @@ jobs:
             ${{ inputs.scan-args }}
         continue-on-error: true
       - name: "Run osv-scanner-reporter"
-        uses: google/osv-scanner-action/osv-reporter-action@3c399db9dd6dd8106a27d280d53c55077d3f7cea # v1.8.1
+        uses: google/osv-scanner-action/osv-reporter-action@f8af5221bae5d45891ae7a23c2f3d0c938334355 # v1.8.2
         with:
           scan-args: |-
             --output=${{ inputs.results-file-name }}

--- a/.github/workflows/osv-scanner-reusable.yml
+++ b/.github/workflows/osv-scanner-reusable.yml
@@ -64,7 +64,7 @@ jobs:
           name: "${{ inputs.download-artifact }}"
           path: "./"
       - name: "Run scanner"
-        uses: google/osv-scanner-action/osv-scanner-action@3c399db9dd6dd8106a27d280d53c55077d3f7cea # v1.8.1
+        uses: google/osv-scanner-action/osv-scanner-action@f8af5221bae5d45891ae7a23c2f3d0c938334355 # v1.8.2
         with:
           scan-args: |-
             --output=results.json
@@ -72,7 +72,7 @@ jobs:
             ${{ inputs.scan-args }}
         continue-on-error: true
       - name: "Run osv-scanner-reporter"
-        uses: google/osv-scanner-action/osv-reporter-action@3c399db9dd6dd8106a27d280d53c55077d3f7cea # v1.8.1
+        uses: google/osv-scanner-action/osv-reporter-action@f8af5221bae5d45891ae7a23c2f3d0c938334355 # v1.8.2
         with:
           scan-args: |-
             --output=${{ inputs.results-file-name }}

--- a/.github/workflows/osv-scanner-unified-workflow.yml
+++ b/.github/workflows/osv-scanner-unified-workflow.yml
@@ -35,7 +35,7 @@ permissions:
 jobs:
   scan-scheduled:
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@3c399db9dd6dd8106a27d280d53c55077d3f7cea" # v1.8.1
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@f1f90c47a30be326ec08bf0e1633cab832421fe0" # v1.8.2
     with:
       # Example of specifying custom arguments
       scan-args: |-
@@ -44,7 +44,7 @@ jobs:
         ./
   scan-pr:
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@3c399db9dd6dd8106a27d280d53c55077d3f7cea" # v1.8.1
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@f1f90c47a30be326ec08bf0e1633cab832421fe0" # v1.8.2
     with:
       # Example of specifying custom arguments
       scan-args: |-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OSV-Scanner CI/CD Action
 
-[![Release v1.8.1](https://img.shields.io/badge/release-v1.8.1-blue?style=flat)](https://github.com/google/osv-scanner-action/releases)
+[![Release v1.8.2](https://img.shields.io/badge/release-v1.8.2-blue?style=flat)](https://github.com/google/osv-scanner-action/releases)
 <!-- Hard coded release version -->
 
 The OSV-Scanner CI/CD action leverages the [OSV.dev](https://osv.dev/) database and the [OSV-Scanner](https://google.github.io/osv-scanner/) CLI tool to track and notify you of known vulnerabilities in your dependencies for over 11 [languages and ecosystems](https://google.github.io/osv-scanner/supported-languages-and-lockfiles/).

--- a/osv-reporter-action/action.yml
+++ b/osv-reporter-action/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: true
 runs:
   using: "docker"
-  image: "docker://ghcr.io/google/osv-scanner-action:v1.8.1"
+  image: "docker://ghcr.io/google/osv-scanner-action:v1.8.2"
   entrypoint: /root/osv-reporter
   args:
     - "${{ inputs.scan-args }}"

--- a/osv-scanner-action/action.yml
+++ b/osv-scanner-action/action.yml
@@ -25,6 +25,6 @@ inputs:
       ./
 runs:
   using: "docker"
-  image: "docker://ghcr.io/google/osv-scanner-action:v1.8.1"
+  image: "docker://ghcr.io/google/osv-scanner-action:v1.8.2"
   args:
     - ${{ inputs.scan-args }}


### PR DESCRIPTION
Created using the update script. 

This PR updates osv-scanner-action to use osv-scanner v1.8.2, and which enables go call analysis by default