### PR TITLE
chore: disable renovate bot updating osv-scanner-action package.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,6 +24,10 @@
         ".github/**"
       ],
       "groupName": "workflows"
+    },
+    {
+      "matchPackageNames": ["osv-scanner-action"],
+      "enabled": false
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -26,7 +26,7 @@
       "groupName": "workflows"
     },
     {
-      "matchPackageNames": ["osv-scanner-action"],
+      "matchPackageNames": ["google/osv-scanner-action"],
       "enabled": false
     }
   ]


### PR DESCRIPTION
Since we update OSV-Scanner-action with every release, there's no need for the renovate bot to [update it](https://github.com/google/osv-scanner-action/pull/34/commits/1e5b4ff3242f30ab5894ce0420a97fa3c8a61a42#diff-b1a2aa2667c25042ca66213caec04049d2c87138105a528ac52104144fe4ff98R59). 
Disables the renovate bot from updating the same package to avoid conflicts.