### PR TITLE
Workflows, add support for matrix strategies

### DIFF
--- a/.github/workflows/osv-scanner-reusable-pr.yml
+++ b/.github/workflows/osv-scanner-reusable-pr.yml
@@ -44,6 +44,10 @@ on:
         description: "Whether to fail the action on vulnerability found"
         type: boolean
         default: true
+      matrix-property:
+          description: "Optional string for matrix strategies (E.g. 'amd64-')"
+          type: string
+          default: ""
 
 jobs:
   osv-scan:
@@ -61,7 +65,7 @@ jobs:
         with:
           scan-args: |-
             --format=json
-            --output=old-results.json
+            --output=${{ inputs.matrix-property }}old-results.json
             ${{ inputs.scan-args }}
       - name: "Checkout current branch"
         # Use -f in case any changes were made by osv-scanner (there should be no changes)
@@ -71,16 +75,16 @@ jobs:
         with:
           scan-args: |-
             --format=json
-            --output=new-results.json
+            --output=${{ inputs.matrix-property }}new-results.json
             ${{ inputs.scan-args }}
         continue-on-error: true
       - name: "Run osv-scanner-reporter"
         uses: google/osv-scanner-action/osv-reporter-action@cbb0295db259bba04d38625792c18646ed18bc89 # v1.9.1
         with:
           scan-args: |-
-            --output=${{ inputs.results-file-name }}
-            --old=old-results.json
-            --new=new-results.json
+            --output=${{ inputs.matrix-property }}${{ inputs.results-file-name }}
+            --old=${{ inputs.matrix-property }}old-results.json
+            --new=${{ inputs.matrix-property }}new-results.json
             --gh-annotations=true
             --fail-on-vuln=${{ inputs.fail-on-vuln }}
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
@@ -90,21 +94,21 @@ jobs:
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: SARIF file
-          path: ${{ inputs.results-file-name }}
+          path: ${{ inputs.matrix-property }}${{ inputs.results-file-name }}
           retention-days: 5
       - name: "Upload old scan json results"
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
-          name: old-json-results
-          path: old-results.json
+          name: ${{ inputs.matrix-property }}old-json-results
+          path: ${{ inputs.matrix-property }}old-results.json
           retention-days: 5
       - name: "Upload new scan json results"
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
-          name: new-json-results
-          path: new-results.json
+          name: ${{ inputs.matrix-property }}new-json-results
+          path: ${{ inputs.matrix-property }}new-results.json
           retention-days: 5
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
@@ -112,7 +116,7 @@ jobs:
         if: ${{ !cancelled() && inputs.upload-sarif == true }}
         uses: github/codeql-action/upload-sarif@f09c1c0a94de965c15400f5634aa42fac8fb8f88 # v3.27.5
         with:
-          sarif_file: ${{ inputs.results-file-name }}
+          sarif_file: ${{ inputs.matrix-property }}${{ inputs.results-file-name }}
       - name: "Error troubleshooter"
         if: ${{ always() && steps.upload_artifact.outcome == 'failure' }}
         run: |

--- a/.github/workflows/osv-scanner-reusable.yml
+++ b/.github/workflows/osv-scanner-reusable.yml
@@ -49,6 +49,10 @@ on:
         description: "Whether to fail the action on vulnerability found"
         type: boolean
         default: true
+      matrix-property:
+        description: "Optional string for matrix strategies (E.g. 'amd64-')"
+        type: string
+        default: ""
 
 jobs:
   osv-scan:
@@ -67,7 +71,7 @@ jobs:
         uses: google/osv-scanner-action/osv-scanner-action@cbb0295db259bba04d38625792c18646ed18bc89 # v1.9.1
         with:
           scan-args: |-
-            --output=results.json
+            --output=${{ inputs.matrix-property }}results.json
             --format=json
             ${{ inputs.scan-args }}
         continue-on-error: true
@@ -75,8 +79,8 @@ jobs:
         uses: google/osv-scanner-action/osv-reporter-action@cbb0295db259bba04d38625792c18646ed18bc89 # v1.9.1
         with:
           scan-args: |-
-            --output=${{ inputs.results-file-name }}
-            --new=results.json
+            --output=${{ inputs.matrix-property }}${{ inputs.results-file-name }}
+            --new=${{ inputs.matrix-property }}results.json
             --gh-annotations=false
             --fail-on-vuln=${{ inputs.fail-on-vuln }}
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
@@ -86,15 +90,15 @@ jobs:
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
-          name: SARIF file
-          path: ${{ inputs.results-file-name }}
+          name: ${{ inputs.matrix-property }}SARIF file
+          path: ${{ inputs.matrix-property }}${{ inputs.results-file-name }}
           retention-days: 5
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
         if: "${{ !cancelled() && inputs.upload-sarif == true }}"
         uses: github/codeql-action/upload-sarif@f09c1c0a94de965c15400f5634aa42fac8fb8f88 # v3.27.5
         with:
-          sarif_file: ${{ inputs.results-file-name }}
+          sarif_file: ${{ inputs.matrix-property }}${{ inputs.results-file-name }}
       - name: "Error troubleshooter"
         if: ${{ always() && steps.upload_artifact.outcome == 'failure' }}
         run: |


### PR DESCRIPTION
This PR attempts to add support for workflows with matrix strategies that use *osc-scanner-action*. 
This PR attempts to allow the user to add a unique value via the `matrix-property` argument. This argument will be appended to all the artifacts generated by scanner and reporter, to avoid duplication errors.

Example of a GitHub workflows:
[Example in Documentation PR](https://github.com/GeoDerp/osv-scanner/blob/actions-matrix-support/docs/github-action.md#using-download-artifact-with-matrix)
```yml
jobs:
  extract-deps:
    strategy:
        fail-fast: false
        matrix:
          platform: [
          {target_arch: amd64},
          {target_arch: armv7}
          {target_arch: armhf},
          {target_arch: aarch64}
        ]
    name: Extract Dependencies
    # ...
    steps:
      # ... Steps to extract your dependencies for each matrix run
      - name: "upload osv-scanner deps" # Upload the deps
        uses: actions/upload-artifact@v4
        with:
          name: ${{ matrix.platform.target_arch }}-OSV-Scanner-deps
          path: osv-scanner-deps.json
          retention-days: 2
  vuln-scan:
    needs:
      - build
    strategy:
      fail-fast: false
      matrix:
        platform: [
          {target_arch: amd64},
          {target_arch: armv7}
          {target_arch: armhf},
          {target_arch: aarch64}
        ]
    uses: "extract/osv-scanner/.github/workflows/osv-scanner-reusable.yml@v1.9.1"
    with:
      download-artifact: "${{ matrix.platform.target_arch }}-OSV-Scanner-deps"
      matrix-property: "${{ matrix.platform.target_arch }}-"
      scan-args: |-
        --lockfile=osv-scanner:osv-scanner-deps.json
        --recursive
        --skip-git
        ./
    permissions:
      security-events: write
      contents: read
      actions: read
```

[EMHASS PR](https://github.com/davidusb-geek/emhass/pull/392)
```yml
#template modified from: https://docs.docker.com/build/ci/github-actions/multi-platform/ & https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images
name: "Publish Docker"

on:
  release:
    types: [published]
  workflow_dispatch:

env:
  REGISTRY: ghcr.io
  IMAGE_NAME: ${{ github.repository }}

jobs:
  build:
    runs-on: ubuntu-latest
    permissions:
      contents: read
      packages: write
      attestations: write
      id-token: write
    strategy:
      fail-fast: false
      matrix:
        platform:
          [
            { target_arch: amd64, os_version: debian },
            { target_arch: armv7, os_version: debian },
            { target_arch: armhf, os_version: raspbian },
            { target_arch: aarch64, os_version: debian },
          ]
    steps:
      # Pull git repo and build each architecture image separately (with QEMU and Buildx)
      - name: lowercase repo
        run: |
          echo "IMAGE_NAME_LOWER=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
      - name: Checkout the repository
        uses: actions/checkout@v4
      - name: Set up QEMU
        uses: docker/setup-qemu-action@v3
      - name: Set up Docker Buildx
        uses: docker/setup-buildx-action@v3
      - name: Log in to the Container registry
        uses: docker/login-action@v3
        with:
          registry: ${{ env.REGISTRY }}
          username: ${{ github.actor }}
          password: ${{ secrets.GITHUB_TOKEN }}

      # Build and save Docker image locally to check security of container packages
      - name: Build Docker image and cache
        id: cache
        uses: docker/build-push-action@v5
        with:
          context: .
          platforms: ${{ matrix.platform.buildx }}
          build-args: |
            TARGETARCH=${{ matrix.platform.target_arch }}
            os_version=${{ matrix.platform.os_version }}
          load: true
      # Extract a list of the installed Debian packages, export as artifact for vulnerability scanning with OSV
      - name: Export Debian package list
        run: mkdir OSV && docker run --rm --entrypoint '/bin/cat' ${{ steps.cache.outputs.imageid }} /var/lib/dpkg/status >> ./OSV/${{ matrix.platform.target_arch }}.status
      - name: Export Python package list
        run: docker run --rm --entrypoint '/usr/bin/pip3' ${{ steps.cache.outputs.imageid }} freeze >> ./OSV/${{ matrix.platform.target_arch }}-requirements.txt
      - name: Upload package list as digest
        uses: actions/upload-artifact@v4
        with:
          name: ${{ matrix.platform.target_arch }}-packages
          path: ./OSV/*
          if-no-files-found: error
          retention-days: 1
      - name: Extract metadata (tags, labels) for Docker
        id: meta
        uses: docker/metadata-action@v5
        with:
          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LOWER }}

      # Build Docker image for pushing to registry
      - name: Build and push Docker image by digest
        id: build
        uses: docker/build-push-action@v5
        with:
          context: .
          platforms: linux/${{ matrix.platform.target_arch }}
          build-args: |
            TARGETARCH=${{ matrix.platform.target_arch }}
            os_version=${{ matrix.platform.os_version }}
          labels: ${{ steps.meta.outputs.labels }}
          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LOWER }},push-by-digest=true,name-canonical=true,push=true
      # Export the build images as artifact for the next job of merging
      - name: Export digest
        run: |
          mkdir -p /tmp/digests
          digest="${{ steps.build.outputs.digest }}"
          touch "/tmp/digests/${digest#sha256:}"
      - name: Upload digest
        uses: actions/upload-artifact@v4
        with:
          name: digests-${{ matrix.platform.target_arch }}
          path: /tmp/digests/*
          if-no-files-found: error
          retention-days: 1

  # Google OSV-Scanner (check known vulnerabilities for Python & Debian packages )
  osv-scan:
    needs:
      - build
    strategy:
      fail-fast: false
      matrix:
        platform:
          [
            { target_arch: amd64 },
            { target_arch: armv7 },
            { target_arch: armhf },
            { target_arch: aarch64 },
          ]
    uses: "geoderp/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v0.0.1"
    with:
      download-artifact: "${{ matrix.platform.target_arch }}-packages"
      matrix-property: "${{ matrix.platform.target_arch }}-"
      scan-args: |-
        --lockfile=dpkg-status:./${{ matrix.platform.target_arch }}.status
        --lockfile=requirements.txt:./${{matrix.platform.target_arch }}-requirements.txt
        --recursive
        --skip-git
        ./
    permissions:
      security-events: write
      contents: read
      actions: read

  # Merge platforms into images into a multi-platform image
  merge:
    if: always()
    runs-on: ubuntu-latest
    permissions:
      packages: write
      contents: read
      attestations: write
      id-token: write
    needs:
      - osv-scan
      - build
    steps:
      - name: lowercase repo
        run: |
          echo "IMAGE_NAME_LOWER=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
      - name: Download digests
        uses: actions/download-artifact@v4
        with:
          path: /tmp/digests
          pattern: digests-*
          merge-multiple: true
      - name: Set up Docker Buildx
        uses: docker/setup-buildx-action@v3
      - name: Extract metadata (tags, labels) for Docker
        id: meta
        uses: docker/metadata-action@v5
        with:
          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LOWER }}
      - name: Log in to the Container registry
        uses: docker/login-action@v3
        with:
          registry: ${{ env.REGISTRY }}
          username: ${{ github.actor }}
          password: ${{ secrets.GITHUB_TOKEN }}
      - name: Create manifest list and push
        working-directory: /tmp/digests
        run: |
          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LOWER }}@sha256:%s ' *)
      - name: Inspect image
        run: |
          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LOWER }}:${{ steps.meta.outputs.version }}

```