### PR TITLE
fix: escape hyphen in release badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OSV-Scanner CI/CD Action
 
-[![Release v2.0.0-beta2](https://img.shields.io/badge/release-v2.0.0-beta2-blue?style=flat)](https://github.com/google/osv-scanner-action/releases)
+[![Release v2.0.0-beta2](https://img.shields.io/badge/release-v2.0.0--beta2-blue?style=flat)](https://github.com/google/osv-scanner-action/releases)
 <!-- Hard coded release version -->
 
 The OSV-Scanner CI/CD action leverages the [OSV.dev](https://osv.dev/) database and the [OSV-Scanner](https://google.github.io/osv-scanner/) CLI tool to track and notify you of known vulnerabilities in your dependencies for over 11 [languages and ecosystems](https://google.github.io/osv-scanner/supported-languages-and-lockfiles/).


### PR DESCRIPTION
- Shields.io splits badge URL fields on hyphens. Replace "v2.0.0-beta2" with "v2.0.0--beta2" to prevent unintended splitting of the version string and ensure the release badge displays correctly.

- Fixes part of #61 