### PR TITLE
Update actions to use v2.2.1 osv-scanner image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OSV-Scanner CI/CD Action
 
-[![Release v2.2.0](https://img.shields.io/badge/release-v2.2.0-blue?style=flat)](https://github.com/google/osv-scanner-action/releases)
+[![Release v2.2.1](https://img.shields.io/badge/release-v2.2.1-blue?style=flat)](https://github.com/google/osv-scanner-action/releases)
 <!-- Hard coded release version -->
 
 The OSV-Scanner CI/CD action leverages the [OSV.dev](https://osv.dev/) database and the [OSV-Scanner](https://google.github.io/osv-scanner/) CLI tool to track and notify you of known vulnerabilities in your dependencies for over 11 [languages and ecosystems](https://google.github.io/osv-scanner/supported-languages-and-lockfiles/).

--- a/osv-reporter-action/action.yml
+++ b/osv-reporter-action/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: true
 runs:
   using: "docker"
-  image: "docker://ghcr.io/google/osv-scanner-action:v2.2.0"
+  image: "docker://ghcr.io/google/osv-scanner-action:v2.2.1"
   entrypoint: /root/osv-reporter
   args:
     - "${{ inputs.scan-args }}"

--- a/osv-scanner-action/action.yml
+++ b/osv-scanner-action/action.yml
@@ -24,6 +24,6 @@ inputs:
       ./
 runs:
   using: "docker"
-  image: "docker://ghcr.io/google/osv-scanner-action:v2.2.0"
+  image: "docker://ghcr.io/google/osv-scanner-action:v2.2.1"
   args:
     - ${{ inputs.scan-args }}


### PR DESCRIPTION
First step to fixing #88 (the reusable action will then need to be updated with the commit SHA for this PR).