### PR TITLE
fix: Update to v2.2.1

### DIFF
--- a/.github/workflows/osv-scanner-reusable-pr.yml
+++ b/.github/workflows/osv-scanner-reusable-pr.yml
@@ -66,7 +66,7 @@ jobs:
           git checkout $GITHUB_BASE_REF
           git submodule update --recursive
       - name: "Run scanner on existing code"
-        uses: google/osv-scanner-action/osv-scanner-action@a0e5dd4ee828f4e99760a98cac452a29afe27cb8 # v2.2.1
+        uses: google/osv-scanner-action/osv-scanner-action@6580e6c1859f468adbb41036916ed6b8d6b49a24 # v2.2.1
         continue-on-error: true
         with:
           scan-args: |-
@@ -79,7 +79,7 @@ jobs:
           git checkout -f $GITHUB_SHA
           git submodule update --recursive
       - name: "Run scanner on new code"
-        uses: google/osv-scanner-action/osv-scanner-action@a0e5dd4ee828f4e99760a98cac452a29afe27cb8 # v2.2.1
+        uses: google/osv-scanner-action/osv-scanner-action@6580e6c1859f468adbb41036916ed6b8d6b49a24 # v2.2.1
         with:
           scan-args: |-
             --format=json
@@ -87,7 +87,7 @@ jobs:
             ${{ inputs.scan-args }}
         continue-on-error: true
       - name: "Run osv-scanner-reporter"
-        uses: google/osv-scanner-action/osv-reporter-action@a0e5dd4ee828f4e99760a98cac452a29afe27cb8 # v2.2.1
+        uses: google/osv-scanner-action/osv-reporter-action@6580e6c1859f468adbb41036916ed6b8d6b49a24 # v2.2.1
         with:
           scan-args: |-
             --output=${{ inputs.matrix-property }}${{ inputs.results-file-name }}

--- a/.github/workflows/osv-scanner-reusable.yml
+++ b/.github/workflows/osv-scanner-reusable.yml
@@ -77,7 +77,7 @@ jobs:
           name: "${{ inputs.download-artifact }}"
           path: "./"
       - name: "Run scanner"
-        uses: google/osv-scanner-action/osv-scanner-action@a0e5dd4ee828f4e99760a98cac452a29afe27cb8 # v2.2.1
+        uses: google/osv-scanner-action/osv-scanner-action@6580e6c1859f468adbb41036916ed6b8d6b49a24 # v2.2.1
         with:
           scan-args: |-
             --output=${{ inputs.matrix-property }}results.json
@@ -85,7 +85,7 @@ jobs:
             ${{ inputs.scan-args }}
         continue-on-error: true
       - name: "Run osv-scanner-reporter"
-        uses: google/osv-scanner-action/osv-reporter-action@a0e5dd4ee828f4e99760a98cac452a29afe27cb8 # v2.2.1
+        uses: google/osv-scanner-action/osv-reporter-action@6580e6c1859f468adbb41036916ed6b8d6b49a24 # v2.2.1
         with:
           scan-args: |-
             --output=${{ inputs.matrix-property }}${{ inputs.results-file-name }}

--- a/.github/workflows/osv-scanner-unified-workflow.yml
+++ b/.github/workflows/osv-scanner-unified-workflow.yml
@@ -35,7 +35,7 @@ permissions:
 jobs:
   scan-scheduled:
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@5aa4a2601a3ce3dbcf36e1679fdb1df7cc2487fd" # v2.2.1
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@8878e971307bf39737f9a806b05c27485055524d" # v2.2.1
     with:
       # Example of specifying custom arguments
       scan-args: |-
@@ -44,7 +44,7 @@ jobs:
         ./
   scan-pr:
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@5aa4a2601a3ce3dbcf36e1679fdb1df7cc2487fd" # v2.2.1
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@8878e971307bf39737f9a806b05c27485055524d" # v2.2.1
     with:
       # Example of specifying custom arguments
       scan-args: |-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OSV-Scanner CI/CD Action
 
-[![Release v2.2.0](https://img.shields.io/badge/release-v2.2.0-blue?style=flat)](https://github.com/google/osv-scanner-action/releases)
+[![Release v2.2.1](https://img.shields.io/badge/release-v2.2.1-blue?style=flat)](https://github.com/google/osv-scanner-action/releases)
 <!-- Hard coded release version -->
 
 The OSV-Scanner CI/CD action leverages the [OSV.dev](https://osv.dev/) database and the [OSV-Scanner](https://google.github.io/osv-scanner/) CLI tool to track and notify you of known vulnerabilities in your dependencies for over 11 [languages and ecosystems](https://google.github.io/osv-scanner/supported-languages-and-lockfiles/).

--- a/osv-reporter-action/action.yml
+++ b/osv-reporter-action/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: true
 runs:
   using: "docker"
-  image: "docker://ghcr.io/google/osv-scanner-action:v2.2.0"
+  image: "docker://ghcr.io/google/osv-scanner-action:v2.2.1"
   entrypoint: /root/osv-reporter
   args:
     - "${{ inputs.scan-args }}"

--- a/osv-scanner-action/action.yml
+++ b/osv-scanner-action/action.yml
@@ -24,6 +24,6 @@ inputs:
       ./
 runs:
   using: "docker"
-  image: "docker://ghcr.io/google/osv-scanner-action:v2.2.0"
+  image: "docker://ghcr.io/google/osv-scanner-action:v2.2.1"
   args:
     - ${{ inputs.scan-args }}


### PR DESCRIPTION
The last update failed to update the tags, so they were still pointing at v2.2.0 (See #90 for why that happened). This fixes that.

Fixes #88
Closes #89 

