### PR TITLE
feat: Simplify release process using relative paths

### DIFF
--- a/.github/workflows/osv-scanner-reusable-pr.yml
+++ b/.github/workflows/osv-scanner-reusable-pr.yml
@@ -66,7 +66,7 @@ jobs:
           git checkout $GITHUB_BASE_REF
           git submodule update --recursive
       - name: "Run scanner on existing code"
-        uses: google/osv-scanner-action/osv-scanner-action@23f8850c0f6fc96b3324529b3f30665d63391634 # v2.2.2
+        uses: ../../osv-scanner-action
         continue-on-error: true
         with:
           scan-args: |-
@@ -79,7 +79,7 @@ jobs:
           git checkout -f $GITHUB_SHA
           git submodule update --recursive
       - name: "Run scanner on new code"
-        uses: google/osv-scanner-action/osv-scanner-action@23f8850c0f6fc96b3324529b3f30665d63391634 # v2.2.2
+        uses: ../../osv-scanner-action
         with:
           scan-args: |-
             --format=json
@@ -87,7 +87,7 @@ jobs:
             ${{ inputs.scan-args }}
         continue-on-error: true
       - name: "Run osv-scanner-reporter"
-        uses: google/osv-scanner-action/osv-reporter-action@23f8850c0f6fc96b3324529b3f30665d63391634 # v2.2.2
+        uses: ../../osv-reporter-action
         with:
           scan-args: |-
             --output=${{ inputs.matrix-property }}${{ inputs.results-file-name }}
@@ -134,3 +134,4 @@ jobs:
         if: ${{ always() && steps.upload_artifact.outcome == 'failure' }}
         run: |
           echo "::error::Artifact upload failed. This is most likely caused by a error during scanning earlier in the workflow."
+

--- a/.github/workflows/osv-scanner-reusable.yml
+++ b/.github/workflows/osv-scanner-reusable.yml
@@ -77,7 +77,7 @@ jobs:
           name: "${{ inputs.download-artifact }}"
           path: "./"
       - name: "Run scanner"
-        uses: google/osv-scanner-action/osv-scanner-action@23f8850c0f6fc96b3324529b3f30665d63391634 # v2.2.2
+        uses: ../../osv-scanner-action
         with:
           scan-args: |-
             --output=${{ inputs.matrix-property }}results.json
@@ -85,7 +85,7 @@ jobs:
             ${{ inputs.scan-args }}
         continue-on-error: true
       - name: "Run osv-scanner-reporter"
-        uses: google/osv-scanner-action/osv-reporter-action@23f8850c0f6fc96b3324529b3f30665d63391634 # v2.2.2
+        uses: ../../osv-reporter-action
         with:
           scan-args: |-
             --output=${{ inputs.matrix-property }}${{ inputs.results-file-name }}
@@ -118,3 +118,4 @@ jobs:
         run: |
           echo "::error::Artifact upload failed. This is most likely caused by a error during scanning earlier in the workflow."
           exit 1
+          

--- a/.github/workflows/osv-scanner-unified-workflow.yml
+++ b/.github/workflows/osv-scanner-unified-workflow.yml
@@ -35,7 +35,7 @@ permissions:
 jobs:
   scan-scheduled:
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9d4732e8b9db0915df9608123133640b58bb6750" # v2.2.2
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.2.2"
     with:
       # Example of specifying custom arguments
       scan-args: |-
@@ -44,10 +44,11 @@ jobs:
         ./
   scan-pr:
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@9d4732e8b9db0915df9608123133640b58bb6750" # v2.2.2
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@v2.2.2"
     with:
       # Example of specifying custom arguments
       scan-args: |-
         --include-git-root
         -r
         ./
+        

--- a/update-script.py
+++ b/update-script.py
@@ -43,11 +43,10 @@ def print_help():
 Performs a series of git merges to update all references of the previous version to the specified tag of osv-scanner. This script expects upstream remote to be named `upstream`
 1. Fetch upstream main branch
 2. Create new branch on the most recent version tag (the last release commit)
-3. Update references to the old osv-scanner tag to the new tag, and make the first commit
-4. Update references to the old .github/workflows/osv-scanner-reusable.yml version to the newly made commit in the last step. Make the second commit.
-5. Finally update the unified workflow to point to the commit made in step 4, perform the third commit.
+3. Update references to the old osv-scanner tag to the new tag.
+4. Commit the changes.
 
-After this script is complete, push the new branch and create a PR. This PR must be merged via a normal git merge commit, NOT a squash commit.
+After this script is complete, push the new branch and create a PR.
 Then create the new release tag on this merged PR commit.''')
 
 
@@ -84,38 +83,5 @@ cmd([
     f'"Update actions to use {target_tag} osv-scanner image"'
 ])
 
-first_commit_hash = cmd(['git', 'rev-parse', 'HEAD'])
-print('First commit hash: ' + first_commit_hash)
-
-find_and_replace_regex_in_file(
-    '.github/workflows/osv-scanner-reusable.yml',
-    'uses: google/osv-scanner-action/osv-(.*?)-action@.*? # .*',
-    f'uses: google/osv-scanner-action/osv-\\1-action@{first_commit_hash} # {target_tag}'
-)
-
-find_and_replace_regex_in_file(
-    '.github/workflows/osv-scanner-reusable-pr.yml',
-    'uses: google/osv-scanner-action/osv-(.*?)-action@.*? # .*',
-    f'uses: google/osv-scanner-action/osv-\\1-action@{first_commit_hash} # {target_tag}'
-)
-
-cmd([
-    'git', 'commit', '-a', '-m',
-    f'Update reusable workflows to point to {target_tag} actions'
-])
-
-second_commit_hash = cmd(['git', 'rev-parse', 'HEAD'])
-print('Second commit hash: ' + second_commit_hash)
-
-find_and_replace_regex_in_file(
-    '.github/workflows/osv-scanner-unified-workflow.yml',
-    'uses: "google/osv-scanner-action/\\.github/workflows/osv-scanner-reusable(.*?)@.*?" # .*',
-    f'uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable\\1@{second_commit_hash}" # {target_tag}'
-)
-
-cmd([
-    'git', 'commit', '-a', '-m',
-    f'Update unified workflow example to point to {target_tag} reusable workflows'
-])
-
 print('Success!')
+  


### PR DESCRIPTION
Refactors the reusable workflows to use relative paths for referencing local actions. This eliminates the need for the complex multi-commit update script.

The `update-script.py` is simplified to only handle version bumps in the action YAML files and the README.

The example workflow (`osv-scanner-unified-workflow.yml`) is updated to use a version tag for clarity.
Fixed : #96 