### PR TITLE
chore: more specific name for uploaded artifact

### DIFF
--- a/.github/workflows/osv-scanner-reusable-pr.yml
+++ b/.github/workflows/osv-scanner-reusable-pr.yml
@@ -101,7 +101,7 @@ jobs:
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
-          name: SARIF file
+          name: OSV Scanner SARIF file
           path: ${{ inputs.matrix-property }}${{ inputs.results-file-name }}
           retention-days: 5
       - name: "Upload old scan json results"

--- a/.github/workflows/osv-scanner-reusable.yml
+++ b/.github/workflows/osv-scanner-reusable.yml
@@ -99,7 +99,7 @@ jobs:
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
-          name: ${{ inputs.matrix-property }}SARIF file
+          name: ${{ inputs.matrix-property }}OSV Scanner SARIF file
           path: ${{ inputs.matrix-property }}${{ inputs.results-file-name }}
           retention-days: 5
       # Upload the results to GitHub's code scanning dashboard.


### PR DESCRIPTION
First thanks for the nice work here.

For context, I recently implemented these reusable workflows in a repository and hit an issue of naming conflicts when uploading an artifact. More details [here](https://github.com/complytime/org-infra/pull/40).

On the caller side this is easily fixed by defining a different name, but making these names more specific reduces the chances of more people hitting the same issue when adopting these reusable workflows.