### PR TITLE
Pin download-artifact action to SHA

### DIFF
--- a/.github/workflows/osv-scanner-reusable.yml
+++ b/.github/workflows/osv-scanner-reusable.yml
@@ -77,7 +77,7 @@ jobs:
           submodules: ${{ inputs.checkout-submodules }}
           ref: ${{ inputs.ref }}
       - name: "Download custom artifact if specified"
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         if: "${{ inputs.download-artifact != '' }}"
         with:
           name: "${{ inputs.download-artifact }}"


### PR DESCRIPTION
Cannot use the `osv-scanner-reusable` due to error:

> Error: The action actions/download-artifact@v8 is not allowed in sv-tools/roas because all actions must be pinned to a full-length commit SHA.