### PR TITLE
feat: gate reusable workflow outputs with a flag

### DIFF
--- a/.github/workflows/osv-scanner-reusable-pr.yml
+++ b/.github/workflows/osv-scanner-reusable-pr.yml
@@ -51,6 +51,10 @@ on:
         description: "Whether to check out submodules or not. Passed on to `submodules` argument of `actions/checkout`"
         type: boolean
         default: false
+      export-results:
+        description: "Whether to export the scan results as job outputs (can fail for large repositories due to size limits)"
+        type: boolean
+        default: false
     outputs:
       old-results:
         description: "Results of the scan before the PR in JSON format"
@@ -111,6 +115,7 @@ jobs:
       # environment variables.
       - name: "Export results"
         id: export
+        if: ${{ inputs.export-results }}
         run: |
           DELIMITER="EOF_$(tr -dc 'a-zA-Z0-9' < /dev/urandom 2>/dev/null | head -c 16)"
           if [ -f ${{ inputs.matrix-property }}old-results.json ]; then

--- a/.github/workflows/osv-scanner-reusable.yml
+++ b/.github/workflows/osv-scanner-reusable.yml
@@ -60,6 +60,10 @@ on:
         description: "Whether to checkout a custom branch/tag/commit for scanning other than the default branch"
         type: string
         default: ""
+      export-results:
+        description: "Whether to export the scan results as job outputs (can fail for large repositories due to size limits)"
+        type: boolean
+        default: false
     outputs:
       results:
         description: "Results of the scan in JSON format"
@@ -104,6 +108,7 @@ jobs:
       # environment variable.
       - name: "Export results"
         id: export
+        if: ${{ inputs.export-results }}
         run: |
           if [ -f ${{ inputs.matrix-property }}osv-results.json ]; then
             DELIMITER="EOF_$(tr -dc 'a-zA-Z0-9' < /dev/urandom 2>/dev/null | head -c 16)"


### PR DESCRIPTION
Introduces a new export-results input parameter (defaulting to false) to both osv-scanner-reusable.yml and osv-scanner-reusable-pr.yml.

This gates the exporting of scan results as job outputs, preventing failures on large repositories due to GitHub's 1MB output limit.

While I mentioned that this is potentially a problem in the initial issue (#99), I didn't follow up on it 🤦 .

Fixes #129