### PR TITLE
fix: address zizmor warnings

### DIFF
--- a/.github/workflows/osv-scanner-reusable-pr.yml
+++ b/.github/workflows/osv-scanner-reusable-pr.yml
@@ -15,11 +15,7 @@
 # OSV-Scanner PR scanning reusable workflow, can be used as a PR action to detect new vulnerabilities being introduced.
 name: "OSV-Scanner PR Scanning"
 
-permissions:
-  # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
-  actions: read
-  contents: read
-  security-events: write
+
 
 on:
   workflow_call:
@@ -70,6 +66,11 @@ on:
 jobs:
   osv-scan:
     runs-on: ${{ inputs.runs-on }}
+    permissions:
+      # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
+      actions: read
+      contents: read
+      security-events: write
     outputs:
       old-results: ${{ steps.export.outputs.old-results }}
       new-results: ${{ steps.export.outputs.new-results }}

--- a/.github/workflows/osv-scanner-reusable-pr.yml
+++ b/.github/workflows/osv-scanner-reusable-pr.yml
@@ -121,16 +121,18 @@ jobs:
       - name: "Export results"
         id: export
         if: ${{ inputs.export-results }}
+        env:
+          MATRIX_PROPERTY: ${{ inputs.matrix-property }}
         run: |
           DELIMITER="EOF_$(tr -dc 'a-zA-Z0-9' < /dev/urandom 2>/dev/null | head -c 16)"
-          if [ -f ${{ inputs.matrix-property }}old-results.json ]; then
+          if [ -f "${MATRIX_PROPERTY}old-results.json" ]; then
             echo "old-results<<${DELIMITER}" >> "${GITHUB_OUTPUT}"
-            cat ${{ inputs.matrix-property }}old-results.json >> "${GITHUB_OUTPUT}"
+            cat "${MATRIX_PROPERTY}old-results.json" >> "${GITHUB_OUTPUT}"
             echo "${DELIMITER}" >> "${GITHUB_OUTPUT}"
           fi
-          if [ -f ${{ inputs.matrix-property }}new-results.json ]; then
+          if [ -f "${MATRIX_PROPERTY}new-results.json" ]; then
             echo "new-results<<${DELIMITER}" >> "${GITHUB_OUTPUT}"
-            cat ${{ inputs.matrix-property }}new-results.json >> "${GITHUB_OUTPUT}"
+            cat "${MATRIX_PROPERTY}new-results.json" >> "${GITHUB_OUTPUT}"
             echo "${DELIMITER}" >> "${GITHUB_OUTPUT}"
           fi
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF

--- a/.github/workflows/osv-scanner-reusable.yml
+++ b/.github/workflows/osv-scanner-reusable.yml
@@ -15,11 +15,7 @@
 # Performs a vulnerability scan with OSV-Scanner and reports the result.
 name: OSV-Scanner single vulnerability scan
 
-permissions:
-  # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
-  actions: read
-  contents: read
-  security-events: write
+
 
 on:
   workflow_call:
@@ -76,6 +72,11 @@ on:
 jobs:
   osv-scan:
     runs-on: ${{ inputs.runs-on }}
+    permissions:
+      # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
+      actions: read
+      contents: read
+      security-events: write
     outputs:
       results: ${{ steps.export.outputs.results }}
     steps:

--- a/.github/workflows/osv-scanner-reusable.yml
+++ b/.github/workflows/osv-scanner-reusable.yml
@@ -114,11 +114,13 @@ jobs:
       - name: "Export results"
         id: export
         if: ${{ inputs.export-results }}
+        env:
+          MATRIX_PROPERTY: ${{ inputs.matrix-property }}
         run: |
-          if [ -f ${{ inputs.matrix-property }}osv-results.json ]; then
+          if [ -f "${MATRIX_PROPERTY}osv-results.json" ]; then
             DELIMITER="EOF_$(tr -dc 'a-zA-Z0-9' < /dev/urandom 2>/dev/null | head -c 16)"
             echo "results<<${DELIMITER}" >> "${GITHUB_OUTPUT}"
-            cat ${{ inputs.matrix-property }}osv-results.json >> "${GITHUB_OUTPUT}"
+            cat "${MATRIX_PROPERTY}osv-results.json" >> "${GITHUB_OUTPUT}"
             echo "${DELIMITER}" >> "${GITHUB_OUTPUT}"
           fi
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF

--- a/.github/workflows/osv-scanner-unified-workflow.yml
+++ b/.github/workflows/osv-scanner-unified-workflow.yml
@@ -24,17 +24,17 @@ on:
   push:
     branches: ["main"]
 
-permissions:
-  # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
-  actions: read
-  # Require writing security events to upload SARIF file to security tab
-  security-events: write
-  # Read commit contents
-  contents: read
 
 jobs:
   scan-scheduled:
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
+    permissions:
+      # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
+      actions: read
+      # Require writing security events to upload SARIF file to security tab
+      security-events: write
+      # Read commit contents
+      contents: read
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@3adb4b14a2b0623876d18d863a498b785fb3752d" # v2.3.8
     with:
       # Example of specifying custom arguments
@@ -44,6 +44,13 @@ jobs:
         ./
   scan-pr:
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+    permissions:
+      # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
+      actions: read
+      # Require writing security events to upload SARIF file to security tab
+      security-events: write
+      # Read commit contents
+      contents: read
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@3adb4b14a2b0623876d18d863a498b785fb3752d" # v2.3.8
     with:
       # Example of specifying custom arguments


### PR DESCRIPTION
This PR addresses several warnings flagged by zizmor:

- Move permissions from workflow level to job level to satisfy `excessive-permissions`.
- Fix potential template injection by using env vars for matrix properties.

Fixes #134 

agy