### PR TITLE
fix: reject symlinked scan result paths in PR reusable workflow

### DIFF
--- a/.github/workflows/osv-scanner-reusable-pr.yml
+++ b/.github/workflows/osv-scanner-reusable-pr.yml
@@ -97,6 +97,24 @@ jobs:
         run: |
           git checkout -f $GITHUB_SHA
           git submodule update --recursive
+      - name: "Guard against symlinked scan result paths"
+        # The checkout above materializes untrusted PR content, which can
+        # include a symlink at one of the fixed result paths used below.
+        # The scanner and reporter write and read these paths with calls
+        # that follow symlinks, so a PR-controlled symlink here (for
+        # example new-results.json -> old-results.json) can clobber the
+        # base scan results and suppress newly introduced findings. Refuse
+        # to continue if any of these paths is a symlink.
+        env:
+          MATRIX_PROPERTY: ${{ inputs.matrix-property }}
+          RESULTS_FILE_NAME: ${{ inputs.results-file-name }}
+        run: |
+          for path in "${MATRIX_PROPERTY}old-results.json" "${MATRIX_PROPERTY}new-results.json" "${MATRIX_PROPERTY}${RESULTS_FILE_NAME}"; do
+            if [ -L "$path" ]; then
+              echo "::error::Refusing to scan through a symlinked result path introduced by the pull request: $path"
+              exit 1
+            fi
+          done
       - name: "Run scanner on new code"
         uses: google/osv-scanner-action/osv-scanner-action@8dc09193bb540e09b23da07ad7e30bd33bf87018 # v2.3.8
         with:


### PR DESCRIPTION
Fixes #136.

## Summary

The PR reusable workflow writes the base scan to `old-results.json`, checks out the untrusted PR commit with `git checkout -f`, then writes the PR scan to `new-results.json` before comparing the two with the reporter. A pull request can add a symlink such as `new-results.json -> old-results.json`. Since the scanner and reporter write and read these paths with calls that follow symlinks, the PR scan output overwrites the base scan output, so the reporter compares the PR scan against itself and reports no newly introduced vulnerabilities. Full detail and a standalone reproduction are in #136.

## Fix

Add a guard step right after the untrusted checkout that refuses to continue if `old-results.json`, `new-results.json`, or the reporter output path is a symlink.

## Testing

I do not have a way to trigger this repository's CI on a fork branch before opening the PR, so I validated the guard logic locally with a shell reproduction outside GitHub Actions.

Case 1, malicious PR symlink: reproduced the `git checkout -f` sequence from the issue, then ran the same guard logic used in the new workflow step. It correctly refused with `Refusing to scan through a symlinked result path introduced by the pull request: new-results.json` and exited non zero.

Case 2, normal run with plain files: ran the same guard logic against ordinary `old-results.json`, `new-results.json`, and `results.sarif` files. It passed without blocking, so the change should not affect a normal scan.

This fix corresponds to a report originally submitted through Google's OSS VRP intake at g.co/vulnz. The triage response asked that it be coordinated here via a public issue and pull request, so filing accordingly.