### PR TITLE
fix: add GOTOOLCHAIN=auto env to osv-scanner calls

### DIFF
--- a/.github/workflows/osv-scanner-reusable-pr.yml
+++ b/.github/workflows/osv-scanner-reusable-pr.yml
@@ -86,6 +86,8 @@ jobs:
           git submodule update --recursive
       - name: "Run scanner on existing code"
         uses: google/osv-scanner-action/osv-scanner-action@8dc09193bb540e09b23da07ad7e30bd33bf87018 # v2.3.8
+        env:
+          GOTOOLCHAIN: auto
         continue-on-error: true
         with:
           scan-args: |-
@@ -99,6 +101,8 @@ jobs:
           git submodule update --recursive
       - name: "Run scanner on new code"
         uses: google/osv-scanner-action/osv-scanner-action@8dc09193bb540e09b23da07ad7e30bd33bf87018 # v2.3.8
+        env:
+          GOTOOLCHAIN: auto
         with:
           scan-args: |-
             --format=json

--- a/.github/workflows/osv-scanner-reusable.yml
+++ b/.github/workflows/osv-scanner-reusable.yml
@@ -93,6 +93,8 @@ jobs:
           path: "./"
       - name: "Run scanner"
         uses: google/osv-scanner-action/osv-scanner-action@8dc09193bb540e09b23da07ad7e30bd33bf87018 # v2.3.8
+        env:
+          GOTOOLCHAIN: auto
         with:
           scan-args: |-
             --output=${{ inputs.matrix-property }}results.json

--- a/osv-scanner-action/action.yml
+++ b/osv-scanner-action/action.yml
@@ -25,5 +25,7 @@ inputs:
 runs:
   using: "docker"
   image: "docker://ghcr.io/google/osv-scanner-action:v2.3.8"
+  env:
+    GOTOOLCHAIN: auto
   args:
     - ${{ inputs.scan-args }}


### PR DESCRIPTION
Add `GOTOOLCHAIN=auto` environment variable to the `osv-scanner` action steps and container action definition.

This resolves issues where `govulncheck` reachability analysis fails when scanning projects targeting newer Go versions than the container release by enabling Go to automatically download required toolchains.

agy