### PR TITLE
Fail the job when a scan does not complete

### DIFF
--- a/.github/workflows/osv-scanner-reusable-pr.yml
+++ b/.github/workflows/osv-scanner-reusable-pr.yml
@@ -85,6 +85,7 @@ jobs:
           git checkout $GITHUB_BASE_REF
           git submodule update --recursive
       - name: "Run scanner on existing code"
+        id: "scan-old"
         uses: google/osv-scanner-action/osv-scanner-action@06b2ab4348248b456ee06c9e953637f55e03504f # v2.5.0
         env:
           GOTOOLCHAIN: auto
@@ -100,6 +101,7 @@ jobs:
           git checkout -f $GITHUB_SHA
           git submodule update --recursive
       - name: "Run scanner on new code"
+        id: "scan-new"
         uses: google/osv-scanner-action/osv-scanner-action@06b2ab4348248b456ee06c9e953637f55e03504f # v2.5.0
         env:
           GOTOOLCHAIN: auto
@@ -109,6 +111,34 @@ jobs:
             --output=${{ inputs.matrix-property }}new-results.json
             ${{ inputs.scan-args }}
         continue-on-error: true
+      # osv-scanner exits non-zero both when it finds vulnerabilities, which the
+      # reporter step below is responsible for acting on, and when the scan itself
+      # fails, so the continue-on-error above cannot tell the two apart. A scan that
+      # fails writes no results file, and the reporter treats a missing --new file as
+      # "no new vulnerabilities" and exits 0. Since the new-code scan runs against the
+      # contents of the pull request, that would let a change which stops the scanner
+      # from completing pass as a clean diff. Compare only scans that produced results.
+      - name: "Check that both scans completed"
+        if: ${{ steps.scan-old.outcome == 'failure' || steps.scan-new.outcome == 'failure' }}
+        env:
+          OLD_OUTCOME: ${{ steps.scan-old.outcome }}
+          NEW_OUTCOME: ${{ steps.scan-new.outcome }}
+          OLD_RESULTS: ${{ inputs.matrix-property }}old-results.json
+          NEW_RESULTS: ${{ inputs.matrix-property }}new-results.json
+        run: |
+          status=0
+          if [ "${OLD_OUTCOME}" = "failure" ] && [ ! -f "${OLD_RESULTS}" ]; then
+            echo "::error::OSV-Scanner failed on the target branch without writing ${OLD_RESULTS}. See the \"Run scanner on existing code\" step for the cause."
+            status=1
+          fi
+          if [ "${NEW_OUTCOME}" = "failure" ] && [ ! -f "${NEW_RESULTS}" ]; then
+            echo "::error::OSV-Scanner failed on this branch without writing ${NEW_RESULTS}. See the \"Run scanner on new code\" step for the cause."
+            status=1
+          fi
+          if [ "${status}" -ne 0 ]; then
+            echo "::error::A scan did not complete, so the two sets of results cannot be compared. Failing the job rather than reporting no new vulnerabilities found."
+          fi
+          exit "${status}"
       - name: "Run osv-scanner-reporter"
         uses: google/osv-scanner-action/osv-reporter-action@06b2ab4348248b456ee06c9e953637f55e03504f # v2.5.0
         with:

--- a/.github/workflows/osv-scanner-reusable-pr.yml
+++ b/.github/workflows/osv-scanner-reusable-pr.yml
@@ -127,11 +127,11 @@ jobs:
           NEW_RESULTS: ${{ inputs.matrix-property }}new-results.json
         run: |
           status=0
-          if [ "${OLD_OUTCOME}" = "failure" ] && [ ! -f "${OLD_RESULTS}" ]; then
+          if [ "${OLD_OUTCOME}" = "failure" ] && [ ! -s "${OLD_RESULTS}" ]; then
             echo "::error::OSV-Scanner failed on the target branch without writing ${OLD_RESULTS}. See the \"Run scanner on existing code\" step for the cause."
             status=1
           fi
-          if [ "${NEW_OUTCOME}" = "failure" ] && [ ! -f "${NEW_RESULTS}" ]; then
+          if [ "${NEW_OUTCOME}" = "failure" ] && [ ! -s "${NEW_RESULTS}" ]; then
             echo "::error::OSV-Scanner failed on this branch without writing ${NEW_RESULTS}. See the \"Run scanner on new code\" step for the cause."
             status=1
           fi

--- a/.github/workflows/osv-scanner-reusable.yml
+++ b/.github/workflows/osv-scanner-reusable.yml
@@ -113,7 +113,7 @@ jobs:
         env:
           RESULTS: ${{ inputs.matrix-property }}results.json
         run: |
-          if [ ! -f "${RESULTS}" ]; then
+          if [ ! -s "${RESULTS}" ]; then
             echo "::error::OSV-Scanner failed without writing ${RESULTS}, so there are no results to report on. Failing the job rather than reporting no vulnerabilities found. See the \"Run scanner\" step for the cause."
             exit 1
           fi

--- a/.github/workflows/osv-scanner-reusable.yml
+++ b/.github/workflows/osv-scanner-reusable.yml
@@ -92,6 +92,7 @@ jobs:
           name: "${{ inputs.download-artifact }}"
           path: "./"
       - name: "Run scanner"
+        id: "scan"
         uses: google/osv-scanner-action/osv-scanner-action@06b2ab4348248b456ee06c9e953637f55e03504f # v2.5.0
         env:
           GOTOOLCHAIN: auto
@@ -101,6 +102,21 @@ jobs:
             --format=json
             ${{ inputs.scan-args }}
         continue-on-error: true
+      # osv-scanner exits non-zero both when it finds vulnerabilities, which the
+      # reporter step below is responsible for acting on, and when the scan itself
+      # fails, so the continue-on-error above cannot tell the two apart. A scan that
+      # fails writes no results file, and the reporter treats a missing --new file as
+      # "no vulnerabilities found" and exits 0, which would turn a failed scan into a
+      # passing check. Report only on a scan that produced results.
+      - name: "Check that the scan completed"
+        if: ${{ steps.scan.outcome == 'failure' }}
+        env:
+          RESULTS: ${{ inputs.matrix-property }}results.json
+        run: |
+          if [ ! -f "${RESULTS}" ]; then
+            echo "::error::OSV-Scanner failed without writing ${RESULTS}, so there are no results to report on. Failing the job rather than reporting no vulnerabilities found. See the \"Run scanner\" step for the cause."
+            exit 1
+          fi
       - name: "Run osv-scanner-reporter"
         uses: google/osv-scanner-action/osv-reporter-action@06b2ab4348248b456ee06c9e953637f55e03504f # v2.5.0
         with:


### PR DESCRIPTION
Both reusable workflows run the scanner under `continue-on-error: true`, because `osv-scanner` exits non-zero when it finds vulnerabilities and the `osv-reporter` step is what decides whether to fail the job:

https://github.com/google/osv-scanner-action/blob/9fd1bcce27f67e3bd819a0a7620e332803dc43bc/.github/workflows/osv-scanner-reusable.yml#L94-L111

That also swallows a scan that failed outright, and the step outcome alone cannot distinguish the two — both are just `failure`. The consequence is that the fail/pass decision is made from a results file that a failed scan never wrote, and `osv-reporter` treats a missing `--new` file as "no vulnerabilities found" and exits 0.

So anything that stops the scanner from completing produces a green check and an empty Code Scanning upload instead of a build failure. The existing `Error troubleshooter` step doesn't catch it: the reporter still writes an empty `results.sarif`, so the artifact upload succeeds.

## Measured

Replaying `osv-scanner-reusable.yml` step for step against the images it pins (`ghcr.io/google/osv-scanner-action:v2.3.8`). "Poisoned" is the same lockfile as "vulnerable" plus one entry that crashes the npm parser (`{"version": "npm:"}`, google/osv-scalibr#2331):

| repo | scanner exit | `results.json` | before | after |
| --- | --- | --- | --- | --- |
| no lockfiles | 0 | missing | SUCCESS | SUCCESS |
| clean lockfile | 0 | present | SUCCESS | SUCCESS |
| 10 known vulns (2 critical, 2 high) | 1 | present | FAILURE | FAILURE |
| same 10 vulns + crash entry | 2 | **missing** | **SUCCESS** | **FAILURE** |

Only the last row changes. Before, the poisoned repo reports `No issues found`, uploads 0 findings to Code Scanning, and merges green while carrying the same dependencies that fail the build one row above.

`osv-scanner-reusable-pr.yml` is the more exposed of the two, since its new-code scan runs against the contents of the pull request. With a clean base and a PR head carrying vulnerable dependencies plus the crash entry:

```
scan-old: exit=0  old-results.json=present
scan-new: exit=2  new-results.json=MISSING
reporter: exit=0  said: No issues found
```

## The fix

Give the scanner steps ids and check that a step which reported `failure` actually produced its results file; fail the job if it didn't.

This keeps every legitimate path intact:

- exit 1 (vulnerabilities found) still writes the file, so the reporter keeps its role of applying `--fail-on-vuln` and the diffing in the PR workflow is untouched;
- a repository with no lockfiles exits 0 — the action's `exit_code_redirect.sh` remaps 128 to 0 — so the guard's `if:` never fires and #65's behaviour is preserved;
- a genuinely failed scan (crash, or exit 129 on an OSV API failure) now fails the job instead of reporting a clean result, which also means "no vulnerabilities" is no longer reported when the vulnerability database was unreachable.

Not reformatted with Prettier: both files already differ from `.prettierrc.json` on `main`, so running it would bury the change in an unrelated diff.

## Disclosure

Reported to Google's OSS VRP first ([issue 536144722](https://issuetracker.google.com/issues/536144722)). Closed as not meeting the bar for a security bug, with an explicit invitation to file publicly, which is what this is.
